### PR TITLE
Add basic RBAC roles

### DIFF
--- a/label_studio/organizations/migrations/0007_organizationmember_role.py
+++ b/label_studio/organizations/migrations/0007_organizationmember_role.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+import django_migration_linter as linter
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('organizations', '0006_alter_organizationmember_deleted_at'),
+    ]
+
+    operations = [
+        linter.IgnoreMigration(),
+        migrations.AddField(
+            model_name='organizationmember',
+            name='role',
+            field=models.CharField(default='ANNOTATOR', max_length=32, choices=[('ADMIN', 'Admin'), ('MANAGER', 'Manager'), ('ANNOTATOR', 'Annotator')]),
+        ),
+    ]

--- a/label_studio/organizations/models.py
+++ b/label_studio/organizations/models.py
@@ -9,6 +9,7 @@ from django.db.models import Count, Q
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from users.models import UserRoles
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,14 @@ class OrganizationMember(OrganizationMemberMixin, models.Model):
     )
     organization = models.ForeignKey(
         'organizations.Organization', on_delete=models.CASCADE, help_text='Organization ID'
+    )
+
+    role = models.CharField(
+        _('role'),
+        max_length=32,
+        choices=UserRoles.choices,
+        default=UserRoles.ANNOTATOR,
+        help_text='Role of the user in this organization',
     )
 
     created_at = models.DateTimeField(_('created at'), auto_now_add=True)

--- a/label_studio/organizations/serializers.py
+++ b/label_studio/organizations/serializers.py
@@ -54,7 +54,7 @@ class OrganizationMemberListSerializer(DynamicFieldsMixin, serializers.ModelSeri
 
     class Meta:
         model = OrganizationMember
-        fields = ['id', 'organization', 'user']
+        fields = ['id', 'organization', 'user', 'role']
 
 
 # =========================================
@@ -74,7 +74,7 @@ class OrganizationMemberSerializer(DynamicFieldsMixin, serializers.ModelSerializ
 
     class Meta:
         model = OrganizationMember
-        fields = ['user', 'organization', 'contributed_projects_count', 'annotations_count', 'created_at']
+        fields = ['user', 'organization', 'role', 'contributed_projects_count', 'annotations_count', 'created_at']
 
 
 class OrganizationInviteSerializer(serializers.Serializer):

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -47,6 +47,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import exception_handler
+from projects.permissions import IsProjectMember
 from tasks.models import Task
 from tasks.serializers import (
     NextTaskSerializer,
@@ -233,6 +234,7 @@ class ProjectListAPI(generics.ListCreateAPIView):
     serializer_class = ProjectSerializer
     filter_backends = [filters.OrderingFilter, DjangoFilterBackend]
     filterset_class = ProjectFilterSet
+    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES
     permission_required = ViewClassPermission(
         GET=all_permissions.projects_view,
         POST=all_permissions.projects_create,
@@ -244,7 +246,7 @@ class ProjectListAPI(generics.ListCreateAPIView):
         serializer.is_valid(raise_exception=True)
         fields = serializer.validated_data.get('include')
         filter = serializer.validated_data.get('filter')
-        projects = Project.objects.filter(organization=self.request.user.active_organization).order_by(
+        projects = Project.objects.for_user(self.request.user).order_by(
             F('pinned_at').desc(nulls_last=True), '-created_at'
         )
         if filter in ['pinned_only', 'exclude_pinned']:
@@ -299,7 +301,7 @@ class ProjectCountsListAPI(generics.ListAPIView):
         serializer = GetFieldsSerializer(data=self.request.query_params)
         serializer.is_valid(raise_exception=True)
         fields = serializer.validated_data.get('include')
-        return Project.objects.with_counts(fields=fields).filter(organization=self.request.user.active_organization)
+        return Project.objects.with_counts(fields=fields).for_user(self.request.user)
 
 
 @method_decorator(
@@ -409,6 +411,7 @@ class ProjectCountsListAPI(generics.ListAPIView):
 class ProjectAPI(generics.RetrieveUpdateDestroyAPIView):
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     queryset = Project.objects.with_counts()
+    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [IsProjectMember]
     permission_required = ViewClassPermission(
         GET=all_permissions.projects_view,
         DELETE=all_permissions.projects_delete,
@@ -425,7 +428,7 @@ class ProjectAPI(generics.RetrieveUpdateDestroyAPIView):
         serializer = GetFieldsSerializer(data=self.request.query_params)
         serializer.is_valid(raise_exception=True)
         fields = serializer.validated_data.get('include')
-        return Project.objects.with_counts(fields=fields).filter(organization=self.request.user.active_organization)
+        return Project.objects.with_counts(fields=fields).for_user(self.request.user)
 
     def get(self, request, *args, **kwargs):
         return super(ProjectAPI, self).get(request, *args, **kwargs)

--- a/label_studio/projects/migrations/0031_projectmember_role.py
+++ b/label_studio/projects/migrations/0031_projectmember_role.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+import django_migration_linter as linter
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('projects', '0030_project_search_vector_index'),
+    ]
+
+    operations = [
+        linter.IgnoreMigration(),
+        migrations.AddField(
+            model_name='projectmember',
+            name='role',
+            field=models.CharField(default='ANNOTATOR', max_length=32, choices=[('ADMIN', 'Admin'), ('MANAGER', 'Manager'), ('ANNOTATOR', 'Annotator')]),
+        ),
+    ]

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -34,6 +34,7 @@ from django.db.models import Avg, BooleanField, Case, Count, GeneratedField, JSO
 from django.db.models.expressions import RawSQL
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from users.models import UserRoles
 from label_studio_sdk._extensions.label_studio_tools.core.label_config import parse_config
 from labels_manager.models import Label
 from projects.functions import (
@@ -85,7 +86,12 @@ class ProjectManager(models.Manager):
     }
 
     def for_user(self, user):
-        return self.filter(organization=user.active_organization)
+        if user.role == UserRoles.ADMIN:
+            return self.filter(organization=user.active_organization)
+        return (
+            self.filter(organization=user.active_organization, members__user=user)
+            .distinct()
+        )
 
     def with_counts(self, fields=None):
         return self.with_counts_annotate(self, fields=fields)
@@ -1234,6 +1240,13 @@ class ProjectMember(models.Model):
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='project_memberships', help_text='User ID'
     )
     project = models.ForeignKey(Project, on_delete=models.CASCADE, related_name='members', help_text='Project ID')
+    role = models.CharField(
+        _('role'),
+        max_length=32,
+        choices=UserRoles.choices,
+        default=UserRoles.ANNOTATOR,
+        help_text='Role of the user in this project',
+    )
     enabled = models.BooleanField(default=True, help_text='Project member is enabled')
     created_at = models.DateTimeField(_('created at'), auto_now_add=True)
     updated_at = models.DateTimeField(_('updated at'), auto_now=True)

--- a/label_studio/projects/permissions.py
+++ b/label_studio/projects/permissions.py
@@ -9,3 +9,12 @@ class ProjectImportPermission(BasePermission):
 
     def has_permission(self, request, view):
         return True
+
+
+class IsProjectMember(BasePermission):
+    """Allow access only to project members or organization admins."""
+
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_organization_admin(obj.organization_id):
+            return True
+        return obj.members.filter(user=request.user, enabled=True).exists()

--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -181,7 +181,10 @@ class TaskListAPI(DMTaskListAPI):
 
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
-        return queryset.filter(project__organization=self.request.user.active_organization)
+        queryset = queryset.filter(project__organization=self.request.user.active_organization)
+        if not self.request.user.is_organization_admin(self.request.user.active_organization_id):
+            queryset = queryset.filter(project__members__user=self.request.user)
+        return queryset
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -853,7 +856,10 @@ class PredictionAPI(viewsets.ModelViewSet):
     filterset_fields = ['task', 'task__project', 'project']
 
     def get_queryset(self):
-        return Prediction.objects.filter(project__organization=self.request.user.active_organization)
+        qs = Prediction.objects.filter(project__organization=self.request.user.active_organization)
+        if not self.request.user.is_organization_admin(self.request.user.active_organization_id):
+            qs = qs.filter(task__project__members__user=self.request.user)
+        return qs
 
 
 @method_decorator(name='get', decorator=extend_schema(exclude=True))

--- a/label_studio/users/migrations/0012_user_role.py
+++ b/label_studio/users/migrations/0012_user_role.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+import django_migration_linter as linter
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0011_user_custom_hotkeys'),
+    ]
+
+    operations = [
+        linter.IgnoreMigration(),
+        migrations.AddField(
+            model_name='user',
+            name='role',
+            field=models.CharField(default='ANNOTATOR', max_length=32, choices=[('ADMIN', 'Admin'), ('MANAGER', 'Manager'), ('ANNOTATOR', 'Annotator')]),
+        ),
+    ]

--- a/label_studio/users/models.py
+++ b/label_studio/users/models.py
@@ -14,7 +14,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from organizations.models import Organization
+from organizations.models import Organization, OrganizationMember
 from rest_framework.authtoken.models import Token
 from users.functions import hash_upload
 
@@ -24,6 +24,12 @@ for r in range(YEAR_START, (datetime.datetime.now().year + 1)):
     YEAR_CHOICES.append((r, r))
 
 year = models.IntegerField(_('year'), choices=YEAR_CHOICES, default=datetime.datetime.now().year)
+
+
+class UserRoles(models.TextChoices):
+    ADMIN = 'ADMIN', 'Admin'
+    MANAGER = 'MANAGER', 'Manager'
+    ANNOTATOR = 'ANNOTATOR', 'Annotator'
 
 
 class UserManager(BaseUserManager):
@@ -116,6 +122,14 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
         'organizations.Organization', null=True, on_delete=models.SET_NULL, related_name='active_users'
     )
 
+    role = models.CharField(
+        _('role'),
+        max_length=32,
+        choices=UserRoles.choices,
+        default=UserRoles.ANNOTATOR,
+        help_text=_('Role of the user within the instance'),
+    )
+
     allow_newsletters = models.BooleanField(
         _('allow newsletters'), null=True, default=None, help_text=_('Allow sending newsletters to user')
     )
@@ -147,7 +161,13 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
                 return settings.HOSTNAME + self.avatar.url
 
     def is_organization_admin(self, org_pk):
-        return True
+        if self.role != UserRoles.ADMIN:
+            return False
+        return OrganizationMember.objects.filter(
+            user=self,
+            organization_id=org_pk,
+            deleted_at__isnull=True,
+        ).exists()
 
     def active_organization_annotations(self):
         return self.annotations.filter(project__organization=self.active_organization)

--- a/label_studio/users/serializers.py
+++ b/label_studio/users/serializers.py
@@ -98,6 +98,7 @@ class BaseUserSerializer(FlexFieldsModelSerializer):
             'avatar',
             'initials',
             'phone',
+            'role',
             'active_organization',
             'active_organization_meta',
             'allow_newsletters',


### PR DESCRIPTION
## Summary
- add `UserRoles` choices and `role` field to user model
- extend organization and project members with role attribute
- filter projects and tasks by role membership
- include role info in serializers
- introduce migrations for new role fields

## Testing
- `pytest -k "" -q` *(fails: PackageNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688223d5ef5c83248270aa9f027b5144