### PR TITLE
Lazy load organization models

### DIFF
--- a/label_studio/users/functions.py
+++ b/label_studio/users/functions.py
@@ -1,17 +1,17 @@
-"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
-"""
+"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license."""
+
 import os
 import uuid
 from time import time
 
 from core.utils.common import load_func
 from django import forms
+from django.apps import apps
 from django.conf import settings
 from django.contrib import auth
 from django.core.files.images import get_image_dimensions
 from django.shortcuts import redirect
 from django.urls import reverse
-from organizations.models import Organization
 
 
 def hash_upload(instance, filename):
@@ -61,6 +61,7 @@ def save_user(request, next_page, user_form):
     user.username = user.email.split('@')[0]
     user.save()
 
+    Organization = apps.get_model('organizations', 'Organization')
     if Organization.objects.exists():
         org = Organization.objects.first()
         org.add_user(user)

--- a/label_studio/users/models.py
+++ b/label_studio/users/models.py
@@ -1,10 +1,10 @@
-"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
-"""
+"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license."""
+
 import datetime
-from typing import Optional
 
 from core.utils.common import load_func
 from core.utils.db import fast_first
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.models import PermissionsMixin
@@ -14,7 +14,6 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from organizations.models import Organization, OrganizationMember
 from rest_framework.authtoken.models import Token
 from users.functions import hash_upload
 
@@ -163,6 +162,7 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
     def is_organization_admin(self, org_pk):
         if self.role != UserRoles.ADMIN:
             return False
+        OrganizationMember = apps.get_model('organizations', 'OrganizationMember')
         return OrganizationMember.objects.filter(
             user=self,
             organization_id=org_pk,
@@ -177,11 +177,13 @@ class User(UserMixin, AbstractBaseUser, PermissionsMixin, UserLastActivityMixin)
         return annotations.values_list('project').distinct().count()
 
     @cached_property
-    def own_organization(self) -> Optional[Organization]:
+    def own_organization(self):
+        Organization = apps.get_model('organizations', 'Organization')
         return fast_first(Organization.objects.filter(created_by=self))
 
     @cached_property
     def has_organization(self):
+        Organization = apps.get_model('organizations', 'Organization')
         return Organization.objects.filter(created_by=self).exists()
 
     def clean(self):


### PR DESCRIPTION
## Summary
- use lazy loading for Organization models in user functions and models
- restore standard quoting and format with blue
- run collectstatic successfully

## Testing
- `ruff format label_studio/users/functions.py label_studio/users/models.py`
- `blue label_studio/users/functions.py label_studio/users/models.py`
- `ruff check label_studio/users/functions.py label_studio/users/models.py`
- `PYTHONPATH=$PWD python label_studio/manage.py collectstatic --no-input`
- `docker build . -f Dockerfile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883106ec9c08324acdbb2ca1a19ea66